### PR TITLE
SchemaとMasterDataの導入、IdDomain,Title,CopyRight追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,43 @@ check and generate Master/UserClasses
       - settings.yaml を変更した場合は python を再起動すること
         - GoogleAuth() のインスタンスを作り直さないと変更が反映されず変なエラーが出たりする
         - e.g. InvalidConfigError: Unknown client_config_backend
+  - 一度ローカル保存してもセッションが切れると認証できなくなる
+    ~~~py
+    $ python load_spreadsheet.py
+    INFO:__main__:[MasterDataConverter] initialize ...
+    INFO:__main__:[MasterDataConverter] authorize ...
+    INFO:__main__:[MasterDataConverter] load file keys ...
+    INFO:__main__:[MasterDataConverter] load master data file list ...
+    INFO:oauth2client.client:Refreshing access_token
+    INFO:oauth2client.client:Failed to retrieve access token: {
+      "error": "invalid_grant",
+      "error_description": "Token has been expired or revoked."
+    }
+    Traceback (most recent call last):
+      File "/usr/local/lib/python3.9/site-packages/pydrive2/auth.py", line 668, in Refresh
+        self.credentials.refresh(self.http)
+      File "/usr/local/lib/python3.9/site-packages/oauth2client/client.py", line 545, in refresh
+        self._refresh(http)
+      File "/usr/local/lib/python3.9/site-packages/oauth2client/client.py", line 761, in _refresh
+        self._do_refresh_request(http)
+      File "/usr/local/lib/python3.9/site-packages/oauth2client/client.py", line 819, in _do_refresh_request
+        raise HttpAccessTokenRefreshError(error_msg, status=resp.status)
+    oauth2client.client.HttpAccessTokenRefreshError: invalid_grant: Token has been expired or revoked.
+
+    During handling of the above exception, another exception occurred:
+
+    Traceback (most recent call last):
+      File "/Users/kazuaki/develop/Unity/EleCuit/EleCuit/Client/Tools/Schema/load_spreadsheet.py", line 125, in <module>
+        mdConverter.load_file_keys()
+      File "/Users/kazuaki/develop/Unity/EleCuit/EleCuit/Client/Tools/Schema/load_spreadsheet.py", line 41, in load_file_keys
+        self.g_auth.LocalWebserverAuth()
+      File "/usr/local/lib/python3.9/site-packages/pydrive2/auth.py", line 131, in _decorated
+        self.Refresh()
+      File "/usr/local/lib/python3.9/site-packages/pydrive2/auth.py", line 670, in Refresh
+        raise RefreshError("Access token refresh failed: %s" % error)
+    pydrive2.auth.RefreshError: Access token refresh failed: invalid_grant: Token has been expired or revoked.
+    ~~~
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ check and generate Master/UserClasses
         - GoogleAuth() のインスタンスを作り直さないと変更が反映されず変なエラーが出たりする
         - e.g. InvalidConfigError: Unknown client_config_backend
   - 一度ローカル保存してもセッションが切れると認証できなくなる
+    - エラーになった場合ローカルの保存ファイルを削除して再度実行するとブラウザで認証画面が表示される
+    - TOdO: 自動でファイル消すようにしたい & セッション切れないようにしたい
     ~~~py
     $ python load_spreadsheet.py
     INFO:__main__:[MasterDataConverter] initialize ...

--- a/Schema/build_schema.py
+++ b/Schema/build_schema.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 import sys
 import os
-import shutil
+import glob
 from repository_path import ProjectPath
 from cs_source_generator import DataCsGenerator, RepositoryCsGenerator
 from master_type import MDTypeInfo, MDTypeManager
@@ -52,6 +52,11 @@ def create_cs_sources(mgr:MDTypeManager, path_dst:Path):
         for value in mgr.dict_info[key].values():
             create_cs_sources_impl(value, path_dst, key)
 
+def remove_cs_files(path: str):
+    for p in glob.glob(path, recursive=True):
+        if os.path.isfile(p):
+            os.remove(p)
+
 if __name__ == "__main__":
     basicConfig(level=INFO)
     args = sys.argv
@@ -59,6 +64,6 @@ if __name__ == "__main__":
 
     dest_dir = ProjectPath.absolute('md_impl')
     if not IS_DEBUG and os.path.isdir(dest_dir):
-        shutil.rmtree(dest_dir)
+        remove_cs_files(str(dest_dir) + "/**/*.cs")
     mgr = MDTypeManager()
     create_cs_sources(mgr, dest_dir)

--- a/Schema/cs_source_generator.py
+++ b/Schema/cs_source_generator.py
@@ -101,7 +101,7 @@ class DataCsGenerator(CsSourceGeneratorBase):
             # e.g. Label = label;
             ctor_definition += self.indent * 3 + 'this.%s = %s;\n' % (field.name, field.name)
         ctor_declaration = ctor_declaration.rstrip(',\n')
-        ctor_declaration += '\n' + self.indent * 2 + ') {\n'
+        ctor_declaration += ')\n' + self.indent * 2 + '{\n'
         ctor_definition = ctor_definition.rstrip(',\n')
         ctor_definition += '\n' + self.indent * 2 + '}\n'
         self.generate_class_body_impl(data_type_name, properties, field_declarations, ctor_declaration + ctor_definition)

--- a/Schema/cs_source_generator.py
+++ b/Schema/cs_source_generator.py
@@ -93,7 +93,7 @@ class DataCsGenerator(CsSourceGeneratorBase):
             pass_type = field.pass_type
             property_name = self.camel_to_pascal_case(field.name)
             # e.g. public string Label { get; }
-            properties += self.indent * 2 + 'public %s %s { get => %s; }\n' % (pass_type, property_name, field.name)
+            properties += self.indent * 2 + 'public %s %s => %s;\n' % (pass_type, property_name, field.name)
             # e.g. [SerializeField] private string label;
             field_declarations += self.indent * 2 + '[SerializeField] private %s %s;\n' % (pass_type, field.name)
             # e.g. MasterHoge(string label, ... ) {

--- a/Schema/load_spreadsheet.py
+++ b/Schema/load_spreadsheet.py
@@ -78,6 +78,7 @@ class MasterDataConverter:
 
     def _worksheet_to_json(self, worksheet:gspread.Worksheet):
         class_name = worksheet.title
+        logger.info('[MasterDataConverter.ConvertToJson] convert %s sheet' % class_name)
         if not class_name in self.records.keys():
             self.records[class_name] = dict()
         field_names = worksheet.row_values(1)

--- a/Schema/load_spreadsheet.py
+++ b/Schema/load_spreadsheet.py
@@ -117,7 +117,9 @@ class MasterDataConverter:
         dest_dir = ProjectPath.absolute('md_json')
         for md_type in self.records:
             dest_file = 'Master%s.json' % md_type
-            output(dest_dir / dest_file, rapidjson.dumps(self.records[md_type], indent=4))
+            full_dict = dict()
+            full_dict['data'] = list(self.records[md_type].values())
+            output(dest_dir / dest_file, rapidjson.dumps(full_dict, indent=4))
 
 if __name__ == "__main__":
     basicConfig(level=INFO)

--- a/Schema/load_spreadsheet.py
+++ b/Schema/load_spreadsheet.py
@@ -117,7 +117,7 @@ class MasterDataConverter:
         dest_dir = ProjectPath.absolute('md_json')
         for md_type in self.records:
             dest_file = 'Master%s.json' % md_type
-            output(dest_dir / dest_file, rapidjson.dumps(self.records[md_type]))
+            output(dest_dir / dest_file, rapidjson.dumps(self.records[md_type], indent=4))
 
 if __name__ == "__main__":
     basicConfig(level=INFO)

--- a/Schema/load_spreadsheet.py
+++ b/Schema/load_spreadsheet.py
@@ -87,6 +87,8 @@ class MasterDataConverter:
         row = 4 # マスタデータのレコードは4行目から
         while True:
             record = worksheet.row_values(row)
+            while len(record) < len(field_types):
+                record.append("")
             if record is None or len(record) < id_column or record[id_column] == '':
                 break # id カラムが空なら全レコードを読み終わったとみなして終了する
             data = dict()

--- a/Schema/master_type.py
+++ b/Schema/master_type.py
@@ -21,7 +21,8 @@ class MDField:
         for attribute in attributes:
             if attribute == 'ID':
                 self.is_id = True
-                self.type_name = 'ID.' + self.type_name
+                self.type_name = 'int'
+                # TOdO: self.type_name = 'ID.' + self.type_name
             if attribute == 'PKey':
                 self.is_primary_key = True
         if not self.is_id:
@@ -33,7 +34,8 @@ class MDField:
     def read_types(self) -> tuple[str, str]:
         # メンバ変数の型
         if self.is_id:
-            raw_type = self.type_name + 'ID'
+            raw_type = 'int'
+            # TOdO: raw_type = self.type_name + 'ID'
         else:
             if self.type_name in MDField.TYPE_DICT:
                 raw_type = MDField.TYPE_DICT[self.type_name]


### PR DESCRIPTION
- 構成
    - Client: https://github.com/EleCuit-02106/Client/pull/10
        - dUnitilityを介してmasterdataを呼び出し使用する
    - dUnitility: https://github.com/directiveXgames/dUnitility/pull/19
        - Data/Master*.jsonをランタイムにロード/アクセスするUtilの提供
    - Schemas: https://github.com/EleCuit-02106/Schemas/pull/2
        - Master: .tomlでMasterDataクラスの構造を定義
        - MasterImpl: Master/*.tomlから生成されたMaster*.cs, Master*Repository.cs
    - Data: https://github.com/EleCuit-02106/Data/pull/1
        - Spreadsheetに入稿されたMasterDataのレコードを変換したMaster*.json
    - Tools: https://github.com/EleCuit-02106/Tools/pull/3
        - Schema/Master/→MasterImpl/への変換スクリプト、SpreadsheetからData/へのロード&変換スクリプト